### PR TITLE
fixing the compatibility in updating Datio instances (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.35.0 (upcoming)
 
+* [ROCK-459] Maintaining the compatibility with Datio descriptor in Stratio scripts about service 
+  instance (DISCOVERY_INSTANCE_NAME)
 * Upgrade to Metabase 0.33.2
 * New Crossdata driver as a plugin 
 

--- a/resources/kms/psql-connection.sh
+++ b/resources/kms/psql-connection.sh
@@ -5,6 +5,11 @@ if [ "$MB_DB_SSL" = "true" ]; then
     INFO "Obtaining and setting TLS secrets for SSL secured Postgres"
 
     SSL_CLUSTER=${SSL_CLUSTER:="userland"}
+    # Datio compatibility
+    if [[ "$TENANT_NAME" != "" ]]; then
+      DISCOVERY_INSTANCE_NAME="$TENANT_NAME"
+    fi
+    #######
     SSL_INSTANCE=${DISCOVERY_INSTANCE_NAME:="crossdata-1"}
     SSL_FQDN=${DISCOVERY_INSTANCE_NAME:="crossdata-1"}
     SSL_FORMAT=${SSL_FORMAT:="PEM"}
@@ -32,7 +37,8 @@ if [ "$MB_DB_SSL" = "true" ]; then
     chown -R root:root $POSTGRESQL_SSL_CERT_LOCATION
     PG_URL="jdbc:postgresql://$PG_HOST:$PG_PORT/$PG_DATABASE?user=$PG_USER\\&ssl=true\\&sslmode=verify-full\\&sslcert=$SSL_PEM_CERT\\&sslkey=$SSL_KEY\\&sslrootcert=$SSL_ROOT_CERT"
 
-    CONNECTION_STRING="postgres://$MB_DB_HOST:$MB_DB_PORT/$MB_DB_DBNAME?user=$DISCOVERY_INSTANCE_NAME&password=$MB_DB_PASS&sslmode=verify-full&sslcert=$SSL_PEM_CERT&sslkey=$SSL_KEY&sslrootcert=$SSL_ROOT_CERT"
+    CONNECTION_STRING="postgres://$MB_DB_HOST:$MB_DB_PORT/$MB_DB_DBNAME?user=$MB_DB_USER&password=$MB_DB_PASS&sslmode=verify-full&sslcert=$SSL_PEM_CERT&sslkey=$SSL_KEY&sslrootcert=$SSL_ROOT_CERT"
+
     INFO $CONNECTION_STRING
 else
     INFO "Connection to PostgresSQL MD5"

--- a/resources/kms/secrets.sh
+++ b/resources/kms/secrets.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+    # Datio compatibility
+    if [[ "$TENANT_NAME" != "" ]]; then
+      DISCOVERY_INSTANCE_NAME="$TENANT_NAME"
+    fi
+    #######
 
 TENANT_UNDERSCORE=${DISCOVERY_INSTANCE_NAME//-/_}
 export TENANT_NORM="${TENANT_UNDERSCORE^^}"

--- a/resources/kms/tls-config.sh
+++ b/resources/kms/tls-config.sh
@@ -2,6 +2,12 @@
 
 INFO "Obtaining and setting TLS secrets for HTTP exposed service"
 
+    # Datio compatibility
+    if [[ "$TENANT_NAME" != "" ]]; then
+      DISCOVERY_INSTANCE_NAME="$TENANT_NAME"
+    fi
+    #######
+
 getCert "userland" "$DISCOVERY_INSTANCE_NAME" "$DISCOVERY_INSTANCE_NAME" "JKS" "/root/kms/secrets" || exit $?
 
 ### Get keystore password


### PR DESCRIPTION
Datio uses TENANT_NAME environmental variable to put the certificate of the service instance. If this variable exists, Discovery uses it instead of DISCOVERY_INSTANCE_NAME.



###### Before submitting the PR, please make sure you do the following 
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein eastwood && lein bikeshed && lein docstring-checker && ./bin/reflection-linter`
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
